### PR TITLE
expired r/aws_dx_gateway_association_proposal deletion

### DIFF
--- a/aws/resource_aws_dx_gateway_association_proposal.go
+++ b/aws/resource_aws_dx_gateway_association_proposal.go
@@ -160,13 +160,23 @@ func resourceAwsDxGatewayAssociationProposalRead(d *schema.ResourceData, meta in
 func resourceAwsDxGatewayAssociationProposalDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dxconn
 
+	proposal, err := describeDirectConnectGatewayAssociationProposal(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error reading Direct Connect Gateway Association Proposal (%s): %s", d.Id(), err)
+	}
+
+	if proposal == nil {
+		log.Printf("[DEBUG] Direct Connect Gateway Association Proposal (%s) not found, removing from state", d.Id())
+		return nil
+	}
+
 	input := &directconnect.DeleteDirectConnectGatewayAssociationProposalInput{
 		ProposalId: aws.String(d.Id()),
 	}
 
 	log.Printf("[DEBUG] Deleting Direct Connect Gateway Association Proposal: %s", d.Id())
 
-	_, err := conn.DeleteDirectConnectGatewayAssociationProposal(input)
+	_, err = conn.DeleteDirectConnectGatewayAssociationProposal(input)
 
 	if err != nil {
 		return fmt.Errorf("error deleting Direct Connect Gateway Association Proposal (%s): %s", d.Id(), err)


### PR DESCRIPTION
As a result of keeping the last known state of the expired resource; when you wish to legitimately run a terraform destroy, a resource does not exist to be deleted. Terraform therefore responds with the following error: 

```
Error: error deleting Direct Connect Gateway Association Proposal (<id>): DirectConnectClientException: Direct Connect Gateway Association Proposal <id> is not found
```

instead a check should be done before deleting, and if resource is `not found` it should just be removed from state instead of trying to delete.

i have achieved this with a check on the empty result of a describe, since the [API](https://github.com/aws/aws-sdk-go/blob/master/service/directconnect/errors.go) does not have an error code exception for a `not found` dx gateway association proposal.

supports https://github.com/terraform-providers/terraform-provider-aws/pull/12221 https://github.com/terraform-providers/terraform-provider-aws/issues/9209